### PR TITLE
Fix typo StreamsReadFilter.StartsWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The complete possibilities are defined by `StreamsReadFilter` type:
 ```fsharp
 type StreamsReadFilter =
     | AllStreams
-    | StarsWith of string
+    | StartsWith of string
     | EndsWith of string
     | Contains of string
 ```

--- a/src/CosmoStore.CosmosDb/EventStore.fs
+++ b/src/CosmoStore.CosmosDb/EventStore.fs
@@ -81,7 +81,7 @@ let private appendEvents getOpts (client:DocumentClient) (storedProcUri:Uri) (st
 
 let private streamsReadToQuery = function
     | AllStreams -> "", ("@_", null)
-    | StarsWith w -> "AND STARTSWITH(e.streamId, @streamId)", ("@streamId", w :> obj)
+    | StartsWith w -> "AND STARTSWITH(e.streamId, @streamId)", ("@streamId", w :> obj)
     | EndsWith w -> "AND ENDSWITH(e.streamId, @streamId)", ("@streamId", w :> obj)
     | Contains t -> "AND CONTAINS(e.streamId, @streamId)", ("@streamId", t :> obj)
 

--- a/src/CosmoStore.TableStorage/EventStore.fs
+++ b/src/CosmoStore.TableStorage/EventStore.fs
@@ -93,7 +93,7 @@ let private getStreams (table:CloudTable) (streamsRead:StreamsReadFilter) =
         | StreamsReadFilter.AllStreams -> true
         | StreamsReadFilter.Contains c -> s.Id.Contains(c)
         | StreamsReadFilter.EndsWith c -> s.Id.EndsWith(c)
-        | StreamsReadFilter.StarsWith c -> s.Id.StartsWith(c)
+        | StreamsReadFilter.StartsWith c -> s.Id.StartsWith(c)
 
     task {
         let token = TableContinuationToken()

--- a/src/CosmoStore/CosmoStore.fs
+++ b/src/CosmoStore/CosmoStore.fs
@@ -17,7 +17,7 @@ type EventsReadRange =
 
 type StreamsReadFilter =
     | AllStreams
-    | StarsWith of string
+    | StartsWith of string
     | EndsWith of string
     | Contains of string
 

--- a/tests/CosmoStore.Tests/BasicTests.fs
+++ b/tests/CosmoStore.Tests/BasicTests.fs
@@ -167,7 +167,7 @@ let streamsTestsSequenced (cfg:TestConfiguration) =
             
             for i in 1..3 do
                 do! addEventToStream i    
-            let! (streams : Stream list) = store.GetStreams (StreamsReadFilter.StarsWith("X2_"))
+            let! (streams : Stream list) = store.GetStreams (StreamsReadFilter.StartsWith("X2_"))
             equal ["X2_"+name] (streams |> List.map (fun x -> x.Id))
             equal 1 streams.Length
         }


### PR DESCRIPTION
Is it ok if we fix this typo? 
I realise it is a breaking change, so maybe it must be done in a major release.

I really like the library, by the way.