### PR TITLE
Make a usable version of getEventByCorrelationId

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -34,6 +34,7 @@ group Marten
     nuget TaskBuilder.fs
     nuget FSharp.Core >= 4.3.4 < 4.5.4
     nuget Marten.FSharp
+    github baronfel/Newtonsoft.Json.FSharp.Idiomatic src/Newtonsoft.Json.FSharp.Idiomatic/Newtonsoft.Json.FSharp.Idiomatic.fs 
     
 group InMemory
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -3475,7 +3475,9 @@ NUGET
       FSharp.Core (>= 4.1.17) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.6)
       System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
-
+GITHUB
+  remote: baronfel/Newtonsoft.Json.FSharp.Idiomatic
+    src/Newtonsoft.Json.FSharp.Idiomatic/Newtonsoft.Json.FSharp.Idiomatic.fs (abe8185653e06893623dd3a39b353afc226fa703)
 GROUP TableStorage
 STORAGE: NONE
 NUGET

--- a/src/CosmoStore.Marten/CosmoStore.Marten.fsproj
+++ b/src/CosmoStore.Marten/CosmoStore.Marten.fsproj
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <Authors>Roman Provazník;Kunjan Dalal</Authors>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <Content Include="paket.references" />
-      <Content Include="RELEASE_NOTES.md" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\CosmoStore\CosmoStore.fsproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Include="MartenConf.fs" />
-      <Compile Include="EventStore.fs" />
-    </ItemGroup>
-    <Import Project="..\..\.paket\Paket.Restore.targets" />
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Roman Provazník;Kunjan Dalal</Authors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\paket-files\marten\baronfel\Newtonsoft.Json.FSharp.Idiomatic\src\Newtonsoft.Json.FSharp.Idiomatic\Newtonsoft.Json.FSharp.Idiomatic.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/Newtonsoft.Json.FSharp.Idiomatic.fs</Link>
+    </Compile>
+    <Content Include="paket.references" />
+    <Content Include="RELEASE_NOTES.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CosmoStore\CosmoStore.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MartenConf.fs" />
+    <Compile Include="EventStore.fs" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/CosmoStore.Marten/paket.references
+++ b/src/CosmoStore.Marten/paket.references
@@ -2,3 +2,4 @@ group Marten
     FSharp.Core
     TaskBuilder.fs
     Marten.FSharp
+    File: Newtonsoft.Json.FSharp.Idiomatic.fs


### PR DESCRIPTION
This adds @baronfel's `Newtonsoft.Json.FSharp.Idiomatic` to provide custom JsonConverters that are more friendly for F# serializing.  

without these custom converters, Marten will save in the database: 

```json
"CorrelationId": {"Case": "Some", "Fields": ["01d6c038-202e-4b60-8568-adbd881d38a8"]}
```

with custom converters, it becomes more normal

```json
"CorrelationId": "01d6c038-202e-4b60-8568-adbd881d38a8"
```

Now that the json that gets serialized turns out to be more predictable, we can use raw sql to query the EventRead table easily.

Although this doesn't use Martens Linq generation, it's the quickest option to getting a production ready version.

