### PR TITLE
Add Storage Account Auth Via SAS Token

### DIFF
--- a/src/CosmoStore.TableStorage/EventStore.fs
+++ b/src/CosmoStore.TableStorage/EventStore.fs
@@ -147,6 +147,9 @@ let getEventStore (configuration:Configuration) =
         | Cloud (accountName, authKey) -> 
             let credentials = Auth.StorageCredentials(accountName, authKey)
             CloudStorageAccount(credentials, true)
+        | CloudBySAS (accountName, sasToken) ->
+            let credentials = Auth.StorageCredentials(sasToken)
+            CloudStorageAccount(credentials, accountName, "core.windows.net", true )
         | LocalEmulator -> CloudStorageAccount.DevelopmentStorageAccount
 
     let eventAppended = Event<EventRead<_,_>>()

--- a/src/CosmoStore.TableStorage/TableStorage.fs
+++ b/src/CosmoStore.TableStorage/TableStorage.fs
@@ -4,6 +4,7 @@ open System
 
 type StorageAccount =
     | Cloud of accountName:string * authKey:string
+    | CloudBySAS of accountName:string * sasToken:string
     | LocalEmulator
 
 type Configuration = {


### PR DESCRIPTION
Hey, my team has been using this library to capture events within our azure storage table, however, we are moving away from using the storage account key as an authorization procedure. Instead, we are switching over to using SAS tokens, and it would be great if we could continue using this library.

I was able to fork the repo and create a version of the library that appeared to work for us. This PR contains the changes I was working with (not a huge change). Is the idea of adding SAS token auth support an idea you'd be able to get behind? And if so, is this implementation appropriate?

Thanks.