### PR TITLE
Compatibility fix for TableStorage stream record from 2.x

### DIFF
--- a/src/CosmoStore.TableStorage/Conversion.fs
+++ b/src/CosmoStore.TableStorage/Conversion.fs
@@ -18,6 +18,11 @@ let entityToStream (x:TableEntity) = {
 }
 
 let updateStreamEntity lastVersion (x:TableEntity) =
+    // If using the library with data from 2.x, the Stream entity would have "Position" set
+    // so it must be updated here or the `versionOrPosition` function will indicate the Stream
+    // is always on the same value of "Position" and events will continue to be written
+    // at the same version over and over again.
+    if x.ContainsKey "Position" then x.["Position"] <- lastVersion |> Nullable
     x.["Version"] <- lastVersion |> Nullable
     x
 


### PR DESCRIPTION
For compatibility the "Position" field is checked first on events, then the "Version" field.

When upgrading the library, if the Stream record was written on a 2.x version, it has the "Position" field on Stream rather than the "Version" field. If the "Version" field was updated but not the "Position" field, then on the next read from the stream, it would get the same old "Position", ignoring the updated "Version". This fixes the compatibility issue when upgrading to use the newer library with older data so that the "Position" and "Version" are both kept up to date.